### PR TITLE
feat: add py.typed PEP 561 marker for downstream type checking

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -22,4 +22,4 @@ Mark items as done with ~~strikethrough~~ when completed via PR.
 1. ~~**Pin dependency versions** — replace `>=` with `~=` or exact pins in `requirements.txt` for reproducible builds~~
 1. **Extract prompt templates** — move inline prompt strings from agents into `src/prompts/` directory for easier tuning without touching agent logic
 1. **Add structured JSON logging option** — add `--log-format json` flag for machine-readable log output
-1. **Add type stubs / py.typed marker** — enable downstream type checking for anyone importing the package
+1. ~~**Add type stubs / py.typed marker** — enable downstream type checking for anyone importing the package~~

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Typing :: Typed",
 ]
 dependencies = [
     "langchain>=0.1.0",
@@ -56,6 +57,9 @@ content-agent = "src.cli:cli"
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["src*"]
+
+[tool.setuptools.package-data]
+"src" = ["py.typed"]
 
 [tool.ruff]
 line-length = 88

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -1,0 +1,30 @@
+"""Tests for PEP 561 py.typed marker and package typing support."""
+
+import pathlib
+
+import src
+
+
+def test_py_typed_marker_exists():
+    """src/py.typed exists — signals PEP 561 compliance to type checkers."""
+    package_dir = pathlib.Path(src.__file__).parent
+    marker = package_dir / "py.typed"
+    assert marker.exists(), "py.typed marker file is missing from the src package"
+
+
+def test_py_typed_marker_is_empty():
+    """py.typed must be a zero-byte file per PEP 561."""
+    package_dir = pathlib.Path(src.__file__).parent
+    marker = package_dir / "py.typed"
+    assert marker.stat().st_size == 0, "py.typed must be empty (zero bytes)"
+
+
+def test_pyproject_includes_typed_classifier():
+    """pyproject.toml declares the 'Typing :: Typed' classifier."""
+    repo_root = pathlib.Path(src.__file__).parent.parent
+    pyproject = repo_root / "pyproject.toml"
+    assert pyproject.exists(), "pyproject.toml not found"
+    content = pyproject.read_text()
+    assert (
+        "Typing :: Typed" in content
+    ), "pyproject.toml is missing the 'Typing :: Typed' classifier"

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -16,6 +16,7 @@ def test_py_typed_marker_is_empty():
     """py.typed must be a zero-byte file per PEP 561."""
     package_dir = pathlib.Path(src.__file__).parent
     marker = package_dir / "py.typed"
+    assert marker.exists(), "py.typed marker file is missing from the src package"
     assert marker.stat().st_size == 0, "py.typed must be empty (zero bytes)"
 
 


### PR DESCRIPTION
## Summary

- Add `src/py.typed` (zero-byte PEP 561 marker) so mypy, pyright, and pylance can use the package's existing inline type annotations without requiring separate stubs
- Add `"Typing :: Typed"` PyPI classifier and declare `py.typed` in `[tool.setuptools.package-data]` so the file is included in wheel/sdist distributions
- Mark BACKLOG.md Priority 3 item done

## Risk Tier

low

## Evidence

- [x] `black --check src/ tests/` passes
- [x] `ruff check src/ tests/` passes
- [x] `pytest --cov=src --cov-fail-under=60` passes (178 tests, non-functional suite)
- [x] New code has tests: `tests/test_typing.py` (3 tests — marker exists, marker is empty, classifier present in pyproject.toml)

## Related Issue

BACKLOG.md Priority 3, item 4 — Add type stubs / py.typed marker

https://claude.ai/code/session_01AeV1HtkoNNrMYdqcoRx6oh